### PR TITLE
라이엇 api를 이용한 유저 정보 저장 및 회원 검사

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,11 +45,12 @@ dependencies {
     //oauth
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
     //jwt
-    //jwt
     implementation("io.jsonwebtoken:jjwt-api:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
     implementation("com.coveo:spring-boot-parameter-store-integration:1.1.2")
+    //json
+    implementation("com.googlecode.json-simple:json-simple:1.1.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -51,6 +51,9 @@ dependencies {
     implementation("com.coveo:spring-boot-parameter-store-integration:1.1.2")
     //json
     implementation("com.googlecode.json-simple:json-simple:1.1.1")
+    //localdate
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+    implementation("com.fasterxml.jackson.core:jackson-databind")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/gg/match/common/config/ObjectMapperConfig.kt
+++ b/src/main/kotlin/gg/match/common/config/ObjectMapperConfig.kt
@@ -1,0 +1,25 @@
+package gg.match.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer
+import com.fasterxml.jackson.module.kotlin.addSerializer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Configuration
+class ObjectMapperConfig {
+    @Bean
+    fun objectMapper(): ObjectMapper {
+        val javaTimeModule = JavaTimeModule()
+        val objectMapper= ObjectMapper()
+        val localDateTimeSerializer = LocalDateTimeSerializer(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+            .withZone(ZoneId.of("Asia/Seoul")))
+        javaTimeModule.addSerializer(LocalDateTime::class, localDateTimeSerializer)
+        objectMapper.registerModule(javaTimeModule)
+        return objectMapper
+    }
+}

--- a/src/main/kotlin/gg/match/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/gg/match/common/config/SecurityConfig.kt
@@ -13,10 +13,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
-import org.springframework.web.cors.CorsConfiguration
-import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.CorsUtils
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
@@ -27,7 +24,7 @@ class SecurityConfig(
     fun webSecurityCustomizer(): WebSecurityCustomizer? {
         return WebSecurityCustomizer { web: WebSecurity ->
             web.ignoring().antMatchers("/api/user/signin", "/api/user/signup", "/api/user/refresh",
-            "/css/**", "/js/**", "/images/**", "/api/lol/**")
+            "/css/**", "/js/**", "/images/**", "/api/lol/user/**", "/api/lol/**")
         }
     }
 
@@ -42,7 +39,8 @@ class SecurityConfig(
             .and()
             .authorizeRequests()
             .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-            .antMatchers("/api/user/signup", "/api/user/signin", "/api/user/refresh", "/api/lol/**").permitAll()
+            .antMatchers("/api/user/signup", "/api/user/signin", "/api/user/refresh", "/api/lol/**",
+                "/api/lol/user/**", "/api/lol/**").permitAll()
             .anyRequest().authenticated()
             .and()
             .cors()
@@ -51,20 +49,6 @@ class SecurityConfig(
 
         return http.build()
     }
-//    에러 해결 Bean 등록이나 없어도 잘 동작하는것 확인, 캐시에러가 아닐 경우 재 추가를 위한 주석처리
-//
-//    @Bean
-//    fun corsConfigurationSource(): CorsConfigurationSource? {
-//        val configuration = CorsConfiguration()
-//        configuration.addAllowedOrigin("http://localhost:3000")
-//        configuration.addAllowedMethod("*")
-//        configuration.addAllowedHeader("*")
-//        configuration.allowCredentials = true
-//        configuration.maxAge = 3600L
-//        val source = UrlBasedCorsConfigurationSource()
-//        source.registerCorsConfiguration("/**", configuration)
-//        return source
-//    }
 
     @Bean
     fun encoder(): PasswordEncoder = BCryptPasswordEncoder()

--- a/src/main/kotlin/gg/match/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/gg/match/common/config/SecurityConfig.kt
@@ -18,7 +18,6 @@ import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.CorsUtils
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
-
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
@@ -52,19 +51,20 @@ class SecurityConfig(
 
         return http.build()
     }
-
-    @Bean
-    fun corsConfigurationSource(): CorsConfigurationSource? {
-        val configuration = CorsConfiguration()
-        configuration.addAllowedOrigin("http://localhost:3000")
-        configuration.addAllowedMethod("*")
-        configuration.addAllowedHeader("*")
-        configuration.allowCredentials = true
-        configuration.maxAge = 3600L
-        val source = UrlBasedCorsConfigurationSource()
-        source.registerCorsConfiguration("/**", configuration)
-        return source
-    }
+//    에러 해결 Bean 등록이나 없어도 잘 동작하는것 확인, 캐시에러가 아닐 경우 재 추가를 위한 주석처리
+//
+//    @Bean
+//    fun corsConfigurationSource(): CorsConfigurationSource? {
+//        val configuration = CorsConfiguration()
+//        configuration.addAllowedOrigin("http://localhost:3000")
+//        configuration.addAllowedMethod("*")
+//        configuration.addAllowedHeader("*")
+//        configuration.allowCredentials = true
+//        configuration.maxAge = 3600L
+//        val source = UrlBasedCorsConfigurationSource()
+//        source.registerCorsConfiguration("/**", configuration)
+//        return source
+//    }
 
     @Bean
     fun encoder(): PasswordEncoder = BCryptPasswordEncoder()

--- a/src/main/kotlin/gg/match/controller/api/LoLController.kt
+++ b/src/main/kotlin/gg/match/controller/api/LoLController.kt
@@ -1,7 +1,6 @@
 package gg.match.controller.api
 
 import gg.match.controller.common.dto.PageResult
-import gg.match.controller.common.entity.Expire
 import gg.match.domain.board.lol.dto.LoLRequestDTO
 import gg.match.domain.board.lol.dto.ReadLoLBoardDTO
 import gg.match.domain.board.lol.entity.Position
@@ -15,11 +14,11 @@ import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/api/lol/board")
+@RequestMapping("/api/lol")
 class LoLController(
     private val loLService: LoLService
 ) {
-    @GetMapping()
+    @GetMapping("/board")
     fun getBoards(
         @PageableDefault(size=10) pageable: Pageable,
         @RequestParam(required = false, defaultValue = "ALL") position: Position,
@@ -29,13 +28,13 @@ class LoLController(
         return loLService.getBoards(pageable, position, type, tier)
     }
 
-    @GetMapping("/{boardId}")
+    @GetMapping("/board/{boardId}")
     fun getBoard(@PathVariable boardId: Long): ResponseEntity<Any> {
         return ResponseEntity.ok(loLService.getBoard(boardId))
     }
 
 
-    @PostMapping
+    @PostMapping("/board")
     fun saveBoard(@RequestBody loLRequestDTO: LoLRequestDTO): ResponseEntity<Any> {
         loLRequestDTO.voice = voiceUpper(loLRequestDTO.voice)
         return try{
@@ -45,7 +44,7 @@ class LoLController(
         }
     }
 
-    @PutMapping("/{boardId}")
+    @PutMapping("/board/{boardId}")
     fun updateBoard(@PathVariable boardId: Long,
                     @RequestBody loLRequestDTO: LoLRequestDTO): ResponseEntity<Any> {
         loLRequestDTO.voice = voiceUpper(loLRequestDTO.voice)
@@ -56,10 +55,15 @@ class LoLController(
         }
     }
 
-    @DeleteMapping("/{boardId}")
+    @DeleteMapping("/board/{boardId}")
     fun delete(@PathVariable boardId: Long): ResponseEntity<Nothing> {
         loLService.delete(boardId)
         return ResponseEntity.ok().body(null)
+    }
+
+    @GetMapping("/user/exist/{nickname}")
+    fun userExist(@PathVariable nickname: String): ResponseEntity<Any> {
+        return ResponseEntity.ok().body(loLService.getUserIsExist(nickname))
     }
 
     fun voiceUpper(voice: String): String{

--- a/src/main/kotlin/gg/match/controller/api/LoLController.kt
+++ b/src/main/kotlin/gg/match/controller/api/LoLController.kt
@@ -63,7 +63,12 @@ class LoLController(
 
     @GetMapping("/user/exist/{nickname}")
     fun userExist(@PathVariable nickname: String): ResponseEntity<Any> {
-        return ResponseEntity.ok().body(loLService.getUserIsExist(nickname))
+        return ResponseEntity.ok().body(loLService.getUserInfoByRiotApi(nickname))
+    }
+
+    @GetMapping("/user/{nickname}")
+    fun saveUserByRiot(@PathVariable nickname: String): ResponseEntity<Any> {
+        return ResponseEntity.ok().body(loLService.saveUserInfoByRiotApi(nickname.trim().replace(" ", "")))
     }
 
     fun voiceUpper(voice: String): String{

--- a/src/main/kotlin/gg/match/controller/api/UserController.kt
+++ b/src/main/kotlin/gg/match/controller/api/UserController.kt
@@ -2,21 +2,25 @@ package gg.match.controller.api
 
 import gg.match.common.annotation.CurrentUser
 import gg.match.common.jwt.util.JwtResolver
+import gg.match.domain.board.lol.service.LoLService
 import gg.match.domain.user.dto.*
 import gg.match.domain.user.entity.User
 import gg.match.domain.user.service.AuthService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDateTime
 import javax.servlet.http.HttpServletRequest
 
 @RestController
 @RequestMapping("/api/user")
 class UserController(
     private val authService: AuthService,
+    private val loLService: LoLService,
     private val jwtResolver: JwtResolver
 ) {
     @PostMapping("/signup")
     fun signup(@RequestBody signUpRequestDTO: SignUpRequestDTO): ResponseEntity<JwtTokenDTO> {
+        signUpRequestDTO.lol?.let { loLService.saveUserInfoByRiotApi(it) }
         return ResponseEntity.ok().body(authService.signUp(signUpRequestDTO))
     }
 
@@ -42,5 +46,10 @@ class UserController(
     @GetMapping("/info")
     fun myInfo(request: HttpServletRequest, @CurrentUser user: User): ResponseEntity<Any> {
         return ResponseEntity.ok().body(user)
+    }
+
+    @GetMapping("/test")
+    fun test(): ResponseEntity<Any>{
+        return ResponseEntity.ok().body(LocalDateTime.now())
     }
 }

--- a/src/main/kotlin/gg/match/controller/error/ErrorCode.kt
+++ b/src/main/kotlin/gg/match/controller/error/ErrorCode.kt
@@ -15,5 +15,7 @@ enum class ErrorCode(
     OAUTH2_FAIL_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않은 엑세스 토큰입니다."),
     EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 리프레시 토큰입니다."),
-    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃한 회원입니다.")
+    LOGOUT_TOKEN(HttpStatus.UNAUTHORIZED, "로그아웃한 회원입니다."),
+    //LOL
+    USER_NOT_RANKED(HttpStatus.NOT_FOUND, "아직 랭크정보를 보유하고 있지 않습니다.")
 }

--- a/src/main/kotlin/gg/match/domain/board/lol/dto/SummonerReadDTO.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/dto/SummonerReadDTO.kt
@@ -1,0 +1,36 @@
+package gg.match.domain.board.lol.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import gg.match.domain.board.lol.entity.Tier
+
+class SummonerReadDTO (
+    @JsonProperty("id")
+    var id: Long,
+
+    @JsonProperty("name")
+    var nickname: String,
+
+    @JsonProperty("tier")
+    var tier: Tier,
+
+    @JsonProperty("rank")
+    var rank: Int,
+
+    @JsonProperty("leaguePoint")
+    var leaguePoint: Int,
+
+    @JsonProperty("wins")
+    var wins: Int,
+
+    @JsonProperty("losses")
+    var losses: Int,
+
+    @JsonProperty("most1Champion")
+    var most1Champion: String,
+
+    @JsonProperty("most2Champion")
+    var most2Champion: String,
+
+    @JsonProperty("most3Champion")
+    var most3Champion: String
+)

--- a/src/main/kotlin/gg/match/domain/board/lol/dto/SummonerReadDTO.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/dto/SummonerReadDTO.kt
@@ -1,23 +1,32 @@
 package gg.match.domain.board.lol.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import gg.match.domain.board.lol.entity.Tier
+import gg.match.domain.board.lol.entity.Summoner
 
 class SummonerReadDTO (
     @JsonProperty("id")
     var id: Long,
 
-    @JsonProperty("name")
-    var nickname: String,
+    @JsonProperty("leagueId")
+    var leagueId: String,
+
+    @JsonProperty("summonerId")
+    var summonerId: String,
+
+    @JsonProperty("summonerName")
+    var summonerName: String,
+
+    @JsonProperty("queueType")
+    var queueType: String,
 
     @JsonProperty("tier")
-    var tier: Tier,
+    var tier: String,
 
     @JsonProperty("rank")
-    var rank: Int,
+    var rank: String,
 
-    @JsonProperty("leaguePoint")
-    var leaguePoint: Int,
+    @JsonProperty("leaguePoints")
+    var leaguePoints: Int,
 
     @JsonProperty("wins")
     var wins: Int,
@@ -25,12 +34,27 @@ class SummonerReadDTO (
     @JsonProperty("losses")
     var losses: Int,
 
-    @JsonProperty("most1Champion")
-    var most1Champion: String,
+    @JsonProperty("hotStreak")
+    var hotStreak: Boolean,
 
-    @JsonProperty("most2Champion")
-    var most2Champion: String,
+    @JsonProperty("veteran")
+    var veteran: Boolean,
 
-    @JsonProperty("most3Champion")
-    var most3Champion: String
-)
+    @JsonProperty("freshBlood")
+    var freshBlood: Boolean,
+
+    @JsonProperty("inactive")
+    var inactive: Boolean
+) {
+    fun toEntity(): Summoner{
+        return Summoner(
+            queueType = queueType,
+            summonerName = summonerName,
+            tier = tier,
+            rank = rank,
+            leaguePoints = leaguePoints,
+            wins = wins,
+            losses = losses
+        )
+    }
+}

--- a/src/main/kotlin/gg/match/domain/board/lol/entity/Summoner.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/entity/Summoner.kt
@@ -1,0 +1,57 @@
+package gg.match.domain.board.lol.entity
+
+import gg.match.domain.board.lol.dto.SummonerReadDTO
+import javax.persistence.*
+
+@Entity
+@Table(name = "summoner")
+class Summoner(
+    //티어, 모스트 3 챔피언, 승률, 주포지션
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long = 0,
+
+    var nickname: String,
+
+    @Enumerated(EnumType.STRING)
+    var tier: Tier,
+
+    var rank: Int,
+
+    var leaguePoint: Int,
+
+    var wins: Int,
+
+    var losses: Int,
+
+    var most1Champion: String,
+
+    var most2Champion: String,
+
+    var most3Champion: String
+){
+    fun toSummonerReadDTO(): SummonerReadDTO{
+        return SummonerReadDTO(
+            id = id,
+            nickname = nickname,
+            tier = tier,
+            rank = rank,
+            leaguePoint = leaguePoint,
+            wins = wins,
+            losses = losses,
+            most1Champion = most1Champion,
+            most2Champion = most2Champion,
+            most3Champion = most3Champion
+        )
+    }
+
+//    fun update(lolRequestDTO: LoLRequestDTO){
+//        name = lolRequestDTO.name
+//        type = lolRequestDTO.type
+//        tier = lolRequestDTO.tier
+//        position = lolRequestDTO.position
+//        voice = lolRequestDTO.voice
+//        content = lolRequestDTO.content
+//        expire = lolRequestDTO.expire
+//    }
+}

--- a/src/main/kotlin/gg/match/domain/board/lol/entity/Summoner.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/entity/Summoner.kt
@@ -1,57 +1,31 @@
 package gg.match.domain.board.lol.entity
 
-import gg.match.domain.board.lol.dto.SummonerReadDTO
 import javax.persistence.*
 
 @Entity
 @Table(name = "summoner")
 class Summoner(
-    //티어, 모스트 3 챔피언, 승률, 주포지션
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     var id: Long = 0,
 
-    var nickname: String,
+    var queueType: String,
 
-    @Enumerated(EnumType.STRING)
-    var tier: Tier,
+    var summonerName: String,
 
-    var rank: Int,
+    var tier: String,
 
-    var leaguePoint: Int,
+    var rank: String,
+
+    var leaguePoints: Int,
 
     var wins: Int,
 
     var losses: Int,
 
-    var most1Champion: String,
+    var most1Champion: String = "garen",
 
-    var most2Champion: String,
+    var most2Champion: String = "galio",
 
-    var most3Champion: String
-){
-    fun toSummonerReadDTO(): SummonerReadDTO{
-        return SummonerReadDTO(
-            id = id,
-            nickname = nickname,
-            tier = tier,
-            rank = rank,
-            leaguePoint = leaguePoint,
-            wins = wins,
-            losses = losses,
-            most1Champion = most1Champion,
-            most2Champion = most2Champion,
-            most3Champion = most3Champion
-        )
-    }
-
-//    fun update(lolRequestDTO: LoLRequestDTO){
-//        name = lolRequestDTO.name
-//        type = lolRequestDTO.type
-//        tier = lolRequestDTO.tier
-//        position = lolRequestDTO.position
-//        voice = lolRequestDTO.voice
-//        content = lolRequestDTO.content
-//        expire = lolRequestDTO.expire
-//    }
-}
+    var most3Champion: String = "lux"
+)

--- a/src/main/kotlin/gg/match/domain/board/lol/entity/Tier.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/entity/Tier.kt
@@ -1,5 +1,5 @@
 package gg.match.domain.board.lol.entity
 
 enum class Tier{
-    ALL, IRON, BRONZE, SILVER, GOLD, PLATINUM, DIAMOND, MASTER
+    ALL, IRON, BRONZE, SILVER, GOLD, PLATINUM, DIAMOND, MASTER, GRANDMASTER, CHALLENGER, UNRANKED
 }

--- a/src/main/kotlin/gg/match/domain/board/lol/repository/SummonerRepository.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/repository/SummonerRepository.kt
@@ -1,0 +1,7 @@
+package gg.match.domain.board.lol.repository
+
+import gg.match.domain.board.lol.entity.Summoner
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SummonerRepository: JpaRepository<Summoner, Long> {
+}

--- a/src/main/kotlin/gg/match/domain/board/lol/service/LoLService.kt
+++ b/src/main/kotlin/gg/match/domain/board/lol/service/LoLService.kt
@@ -1,28 +1,41 @@
 package gg.match.domain.board.lol.service
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import gg.match.controller.common.dto.PageResult
+import gg.match.controller.error.BusinessException
+import gg.match.controller.error.ErrorCode
 import gg.match.domain.board.lol.repository.LoLRepository
 import gg.match.domain.board.lol.dto.LoLRequestDTO
 import gg.match.domain.board.lol.dto.ReadLoLBoardDTO
+import gg.match.domain.board.lol.dto.SummonerReadDTO
 import gg.match.domain.board.lol.entity.Position
 import gg.match.domain.board.lol.entity.Tier
 import gg.match.domain.board.lol.entity.Type
+import gg.match.domain.board.lol.repository.SummonerRepository
 import org.apache.http.HttpResponse
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClientBuilder
+import org.apache.http.util.EntityUtils
+import org.json.simple.JSONArray
+import org.json.simple.JSONObject
+import org.json.simple.parser.JSONParser
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import java.net.http.HttpClient
 
 @Service
 @Transactional(readOnly = true)
 class LoLService(
     @Value("\${lol.mykey}") private val lolApiKey: String,
-    private val loLRepository: LoLRepository
+    private val loLRepository: LoLRepository,
+    private val summonerRepository: SummonerRepository,
+    private val objectMapper: ObjectMapper
 ) {
+    private val serverUrl = "https://kr.api.riotgames.com"
+    val parser = JSONParser()
+
     fun getBoards(pageable: Pageable, position: Position, type: Type, tier: Tier): PageResult<ReadLoLBoardDTO> {
         val boards = if(type == Type.valueOf("ALL")){
             loLRepository.findByPositionAndTier(pageable, position, tier)
@@ -56,31 +69,48 @@ class LoLService(
     fun delete(boardId: Long) {
         val board = loLRepository.findByIdOrNull(boardId)
             ?: throw Exception("not found")
-
         loLRepository.delete(board)
-    }
-
-    fun getUserIsExist(nickname: String): Boolean {
-        val response = getUserInfoByRiotApi(nickname) ?: return false
-        if(response.statusLine.statusCode != 200){
-            return false
-        }
-        return true
     }
 
     @Transactional
     fun saveUserInfoByRiotApi(nickname: String) {
-        return
+        val parser = JSONParser()
+        val responseUser = getUserInfoByRiotApi(nickname)
+        if (responseUser != null) {
+            try {
+                var request = HttpGet("$serverUrl/lol/league/v4/entries/by-summoner/$responseUser?api_key=$lolApiKey")
+                var responseSummoner: HttpResponse = HttpClientBuilder.create().build().execute(request)
+                var userJson = parser.parse(EntityUtils.toString(responseSummoner.entity, "UTF-8")) as JSONArray
+                if(userJson.isEmpty()){
+                    return
+                }
+                else{
+                    for(i in 0 until userJson.size){
+                        summonerRepository.save(objectMapper.readValue(userJson[i].toString(), SummonerReadDTO::class.java).toEntity())
+                    }
+                }
+            } catch (e: Exception){
+                e.printStackTrace()
+            }
+        }
     }
 
-    fun getUserInfoByRiotApi(nickname: String): HttpResponse? {
-        val serverUrl = "https://kr.api.riotgames.com"
+    fun getUserInfoByRiotApi(nickname: String): Any? {
         return try {
-            val request = HttpGet("$serverUrl/lol/summoner/v4/summoners/by-name/$nickname?api_key=$lolApiKey")
-            HttpClientBuilder.create().build().execute(request)
+            var request = HttpGet("$serverUrl/lol/summoner/v4/summoners/by-name/$nickname?api_key=$lolApiKey")
+            var riotUser = HttpClientBuilder.create().build().execute(request)
+            if(riotUser.statusLine.statusCode == 404){
+                println("여기옴")
+                throw BusinessException(ErrorCode.USER_NOT_FOUND)
+            }
+            if(riotUser.statusLine.statusCode != 200){
+                throw BusinessException(ErrorCode.USER_NOT_RANKED)
+            }
+            var riotUserJson = parser.parse(EntityUtils.toString(riotUser.entity, "UTF-8")) as JSONObject
+            riotUserJson["id"]
         } catch (e: Exception) {
             e.printStackTrace()
-            null
+            throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
         }
     }
 }

--- a/src/main/kotlin/gg/match/domain/user/entity/User.kt
+++ b/src/main/kotlin/gg/match/domain/user/entity/User.kt
@@ -3,7 +3,7 @@ package gg.match.domain.user.entity
 import gg.match.domain.user.dto.Oauth2UserDTO
 import gg.match.domain.user.dto.SignUpRequestDTO
 import org.springframework.data.annotation.CreatedDate
-import java.time.LocalDate
+import java.time.LocalDateTime
 import javax.persistence.*
 
 @Entity
@@ -42,7 +42,7 @@ class User(
 
     @CreatedDate
     @Column(name = "created", updatable = false)
-    var regdate: LocalDate
+    var created: LocalDateTime = LocalDateTime.now()
 
 ) {
     companion object {
@@ -57,8 +57,7 @@ class User(
                 overwatch = signUpRequestDTO.overwatch,
                 pubg = signUpRequestDTO.pubg,
                 maplestory = signUpRequestDTO.maplestory,
-                lostark = signUpRequestDTO.lostark,
-                regdate = LocalDate.now()
+                lostark = signUpRequestDTO.lostark
             )
         }
     }

--- a/src/main/kotlin/gg/match/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/gg/match/domain/user/service/AuthService.kt
@@ -1,7 +1,6 @@
 package gg.match.domain.user.service
 
 import gg.match.common.jwt.service.JwtService
-import gg.match.common.jwt.util.JwtResolver
 import gg.match.common.util.Constants.Companion.REFRESH_TOKEN_PREFIX
 import gg.match.controller.error.BusinessException
 import gg.match.controller.error.ErrorCode
@@ -18,8 +17,7 @@ class AuthService(
     private val userService: UserService,
     private val oAuth2ServiceFactory: OAuth2ServiceFactory,
     private val jwtService: JwtService,
-    private val refreshService: RefreshService,
-    private val jwtResolver: JwtResolver
+    private val refreshService: RefreshService
 ) {
     @Transactional
     fun signUp(signUpRequestDTO: SignUpRequestDTO): JwtTokenDTO{


### PR DESCRIPTION
## 연결된 이슈 번호
> - #31 
## 작업 내용
- 라이엇 api를 통한 회원 여부 검증 진행
- 라이엇 api를 통한 회원 정보 저장
- 유저 정보 불러오기 수정
- object Mapper 관련 java version issue 해결
- configuration 수정 및 삭제
## 회의 내역
- 회의할 내역을 적어주세요